### PR TITLE
Fixed manually created signals links

### DIFF
--- a/Nextras/Application/UI/SecuredLinksPresenterTrait.php
+++ b/Nextras/Application/UI/SecuredLinksPresenterTrait.php
@@ -55,11 +55,16 @@ trait SecuredLinksPresenterTrait
 			$signal = strtr(rtrim($destination, '!'), ':', '-');
 			$a = strrpos($signal, '-');
 			if ($a !== FALSE) {
+				if ($component instanceof Nette\Application\UI\Presenter && substr($destination, -1) !== '!') {
+					break;
+				}
+
 				$component = $component->getComponent(substr($signal, 0, $a));
 				$signal = (string) substr($signal, $a + 1);
 			}
+
 			if ($signal == NULL) { // intentionally ==
-				throw new Nette\Application\UI\InvalidLinkException("Signal must be non-empty string.");
+				throw new Nette\Application\UI\InvalidLinkException('Signal must be non-empty string.');
 			}
 
 			// only PresenterComponent


### PR DESCRIPTION
When I manually create link to signal

``` php
$presenter->link(':Forum:Categories:', array('do' => 'login-google-response'));
```

the trait screams, that the component `-forum-categories` doesn't exists.

I'm not entirely sure if this is the best possible fix, but it solved my issue (that one signal is not supposed to be secured by nextras signals trait).
