### PR TITLE
Fixed compatibility with Kdyby\Google

### DIFF
--- a/Nextras/Application/UI/SecuredLinksPresenterTrait.php
+++ b/Nextras/Application/UI/SecuredLinksPresenterTrait.php
@@ -52,6 +52,10 @@ trait SecuredLinksPresenterTrait
 				$destination = substr($destination, $a + 2);
 			}
 
+			if (strpos($destination, '!') === FALSE) {
+				break;
+			}
+
 			$signal = strtr(rtrim($destination, '!'), ':', '-');
 			$a = strrpos($signal, '-');
 			if ($a !== FALSE) {


### PR DESCRIPTION
Whe you use Kdyby\Google and this extension, there is a problem, because google ext is trying to create oauth link with DO parametere, therefore this trait try to create secure link and app raise error:

Exception in Nette\Application\UI\Link::__toString(): Component or subcomponent name must not be empty string.

The $destination parameter of createSecuredLink (https://github.com/nextras/secured-links/blob/master/Nextras/Application/UI/SecuredLinksPresenterTrait.php#L31) contain :Module:Presenter: and when it's converted to signal (https://github.com/nextras/secured-links/blob/master/Nextras/Application/UI/SecuredLinksPresenterTrait.php#L55) we have got -module-presenter- and this is the reason why it fail here: https://github.com/nextras/secured-links/blob/master/Nextras/Application/UI/SecuredLinksPresenterTrait.php#L58

So i added aditional condition which is looking for exclamation mark in destination and when is not found, secured link is not created.

I'm not 100% sure if this fix is ok, but now it works for me. Secured links are created & google oauth link too.
