### PR TITLE
Drop abandoned nette/reflection dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
 	"require": {
 		"php": "^7.1",
 		"nette/application": "^3.0.3",
-		"nette/utils": "^3.0",
-		"nette/reflection": "^2.4"
+		"nette/utils": "^3.0"
 	},
 	"require-dev": {
 		"nette/tester": "^2.2",

--- a/src/SecuredLinksControlTrait.php
+++ b/src/SecuredLinksControlTrait.php
@@ -41,8 +41,8 @@ trait SecuredLinksControlTrait
 		$secured = FALSE;
 
 		if (method_exists($this, $method)) {
-			$reflection = new Nette\Reflection\Method($this, $method);
-			$secured = $reflection->hasAnnotation('secured');
+			$reflection = new \ReflectionMethod($this, $method);
+			$secured = Nette\Application\UI\ComponentReflection::parseAnnotation($reflection, 'secured') !== NULL;
 			if ($secured) {
 				$params = array($this->getUniqueId());
 				if ($this->params) {


### PR DESCRIPTION
`nette/reflection` is abandoned and its not really needed for `nextras/secured-links`.
The only possible benefit might be caching of annotations, but given the fact that `signalReceived()` is called at most once per request, it can be safely dropped without any significant impact.