### PR TITLE
fix "PHP 8 requires both annotation and attribute to create secured link

### DIFF
--- a/src/SecuredLinksPresenterTrait.php
+++ b/src/SecuredLinksPresenterTrait.php
@@ -68,10 +68,7 @@ trait SecuredLinksPresenterTrait
 			$method = $component->formatSignalMethod($signal);
 			$signalReflection = $reflection->getMethod($method);
 
-			if (!$signalReflection->hasAnnotation('secured')) {
-				break;
-			}
-			if (method_exists($signalReflection, 'getAttributes') && count($signalReflection->getAttributes(Secured::class)) === 0) {
+			if (!($signalReflection->hasAnnotation('secured') || (method_exists($signalReflection, 'getAttributes') && count($signalReflection->getAttributes(Secured::class)) > 0))) {
 				break;
 			}
 


### PR DESCRIPTION
Fixes #40 .

The condition now became quite complicated, but did not find a better way to write it. 