### PR TITLE
Support for nette/application 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"nette/application": "^3.1.5",
+		"nette/application": "^3.2",
 		"nette/utils": "^3.0 || ^4.0"
 	},
 	"require-dev": {

--- a/src/SecuredLinksControlTrait.php
+++ b/src/SecuredLinksControlTrait.php
@@ -52,7 +52,7 @@ trait SecuredLinksControlTrait
 						}
 						if (isset($this->params[$param->name])) {
 							$params[$param->name] = $this->params[$param->name];
-							$type = Nette\Application\UI\ComponentReflection::getParameterType($param);
+							$type = Nette\Application\UI\ComponentReflection::getType($param);
 							Nette\Application\UI\ComponentReflection::convertType($params[$param->name], $type);
 						}
 					}


### PR DESCRIPTION
In `nette/application` v 3.2 method `getParameterType()` of class `Nette\Application\UI\ComponentReflection` was renamed to `getType()`